### PR TITLE
Fix Uncaught in promise errors in console when no catch is provided

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -59,6 +59,10 @@ function createFunctions(Reflux, PromiseFactory) {
             }
         });
 
+        // Ensure that the promise does trigger "Uncaught (in promise)" errors in console if no error handler is added
+        // See: https://github.com/reflux/reflux-promise/issues/4
+        createdPromise.catch(function() {});
+
         return createdPromise;
     }
 


### PR DESCRIPTION
Issue: https://github.com/reflux/reflux-promise/issues/4

This approach feels a bit hacky perhaps but it employs the suggestions from

https://github.com/reflux/refluxjs/issues/403

That users call these asyncResult actions using

```
action().catch(function(){});
```

It just does this in the library automatically so that if the user does not provide a catch (and they shouldnt have to) it is not a browser/console error.
