### PR TITLE
Configurable default catch handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ Reflux.use(RefluxPromise(Q.Promise));
 // Uses bluebird
 import bluebird from "bluebird";
 Reflux.use(RefluxPromise(bluebird))
+
+// Catching and logging unhandled exceptions in action handlers
+import bluebird from "bluebird";
+Reflux.use(RefluxPromise(bluebird, function(err) {
+    console.log(err);
+}))
 ```
 
 ### Extensions to Asynchronous actions

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-function createFunctions(Reflux, PromiseFactory) {
+function createFunctions(Reflux, PromiseFactory, catchHandler) {
 
     const _ = Reflux.utils;
 
@@ -59,9 +59,10 @@ function createFunctions(Reflux, PromiseFactory) {
             }
         });
 
-        // Ensure that the promise does trigger "Uncaught (in promise)" errors in console if no error handler is added
-        // See: https://github.com/reflux/reflux-promise/issues/4
-        createdPromise.catch(function() {});
+        // Attach promise catch handler if provided
+        if (typeof (catchHandler) === "function") {
+            createdPromise.catch(catchHandler);
+        }
 
         return createdPromise;
     }
@@ -129,9 +130,9 @@ function createFunctions(Reflux, PromiseFactory) {
 /**
  * Sets up reflux with Promise functionality
  */
-export default function(promiseFactory) {
+export default function(promiseFactory, catchHandler) {
     return function(Reflux) {
-        const { triggerPromise, promise, listenAndPromise } = createFunctions(Reflux, promiseFactory);
+        const { triggerPromise, promise, listenAndPromise } = createFunctions(Reflux, promiseFactory, catchHandler);
         Reflux.PublisherMethods.triggerAsync = triggerPromise;
         Reflux.PublisherMethods.promise = promise;
         Reflux.PublisherMethods.listenAndPromise = listenAndPromise;


### PR DESCRIPTION
This patch allows initializing reflux-promise with default promise catch handler.

If function is not provided, no catch handler is not attached by reflux-promise. Which is important, because you might want to use error handling of your promise implementation instead.

For example, Bluebird fires an unhandledRejection event on unhandled exceptions. With current catch handler implementation this is never thrown.

Thoughts?
