### PR TITLE
Update reflux-core peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reflux-promise",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Extension to reflux-core to use Promises.",
   "main": "lib/index.js",
   "scripts": {
@@ -30,7 +30,7 @@
     "url": "http://github.com/reflux/reflux-promise/issues"
   },
   "peerDependencies": {
-    "reflux-core": "^0.3.0"
+    "reflux-core": "^1.0.0"
   },
   "devDependencies": {
     "babel": "^5.8.19",


### PR DESCRIPTION
I got a warning after running `npm install reflux-promise`: 
`npm WARN reflux-promise@1.0.4 requires a peer of reflux-core@^0.3.0 but none was installed.`

This happens even if I when version 1.0.0 of `reflux-core` is installed (or in package.json). 

I wrote this small PR to update the peer dependency. 